### PR TITLE
Create MANIFEST.in

### DIFF
--- a/include-LICENSE-include-README.rst-recursive-include-cookie_policy/static-recursive-include-cookie_policy/MANIFEST.in
+++ b/include-LICENSE-include-README.rst-recursive-include-cookie_policy/static-recursive-include-cookie_policy/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE
+include README.rst
+recursive-include cookie_policy/static *
+recursive-include cookie_policy/templates *
+recursive-include docs *


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.8/intro/reusable-apps/
"Only Python modules and packages are included in the package by default. To include additional files, we’ll need to create a MANIFEST.in file. The setuptools docs referred to in the previous step discuss this file in more details. To include the templates, the README.rst and our LICENSE file, create a file django-polls/MANIFEST.in with the following contents:"
